### PR TITLE
updated temp condition from 'lang' to 'units'

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -85,7 +85,7 @@ update: (output, domEl) ->
 
     # --- show current weather conditions
     current = weatherData.currently.temperature.toFixed(1)
-    if lang == 'de' then current += '°C - '
+    if units == 'ca' then current += '°C - '
     else current += '°F - '
     current += weatherData.currently.summary
     $(domEl).find('.conditions').html(current)


### PR DESCRIPTION
Liked your widget a lot, but noticed that the temperature units where still 'F' instead of the selected 'C' for English language. Updated the condition from lang == 'de' to units == 'ca'. 